### PR TITLE
Update the helloworld deployment

### DIFF
--- a/kubernetes/deployments/helloworld.yaml
+++ b/kubernetes/deployments/helloworld.yaml
@@ -17,7 +17,7 @@ spec:
         version: v1
     spec:
       containers:
-      - image: gcr.io/peinau-187709/helloworld:1.0.5
+      - image: gcr.io/peinau-187709/helloworld:1.0.6
         name: helloworld
         ports:
         - containerPort: 80


### PR DESCRIPTION
This commit updates the helloworld deployment container image to:

    gcr.io/peinau-187709/helloworld:1.0.6

Build ID: 95bc0774-bb82-4f65-9eff-f5fa63b66a2f